### PR TITLE
[ENH-20201220-02] Drop the kml plugin in favor of the native GeoJson …

### DIFF
--- a/App/desktop.html
+++ b/App/desktop.html
@@ -17,10 +17,6 @@
       integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew==" crossorigin="">
     </script>
 
-    <!-- Leaflet.KML -->
-    <script src="L.KML.js">
-    </script>
-
     <!-- Leaflet.Legend -->
     <link rel="stylesheet" href="https://ptma.github.io/Leaflet.Legend/src/leaflet.legend.css"/>
     <script src="https://ptma.github.io/Leaflet.Legend/src/leaflet.legend.js">
@@ -29,6 +25,10 @@
     <!-- Geoplugin  -->
     <script src="http://www.geoplugin.net/javascript.gp">
     </script>
+
+    <!-- Wsaero -->
+    <link rel="stylesheet" href="wsaero.css"/>
+
   </head> 
 
   <body onload="Load()" style="height:100%"> 
@@ -54,7 +54,7 @@
 
     var thisUrl = document.URL.replace(/\\/g,'/').replace(/\/[^\/]*$/, '');
     var map;
-    var kmlLayer = null;
+    var dataLayer = null;
     var zoomAlerted = false;
     var mapZoom = 0;
 
@@ -89,34 +89,63 @@
 
     }
 
-    function AddKmlLayer(e) {
+    function onEachFeature (feature, layer) {
+
+      var popupText = "";
+
+      popupText += "<strong>" + feature.properties.name + "</strong>";
+      if (feature.properties.metar) {
+        popupText += "<p>" + feature.properties.metar + "</p>";
+      }
+      if (feature.properties.taf) {
+        popupText += "<p>" + feature.properties.taf + "</p>";
+      }
+
+      layer.bindPopup(popupText);
+      layer.bindTooltip(feature.properties.name);
+
+    }
+
+    function pointToLayer(geoJsonPoint, latlng) {
+
+      var iconClass = geoJsonPoint.properties.flightCat;
+      var iconText = iconClass.substr(0, 1);
+      var myIcon = L.divIcon( {className: iconClass, html: iconText, iconSize: [24, 24]} );
+      return L.marker(latlng, {icon: myIcon});
+
+    }
+
+    function AddDataLayer(e) {
 
       // The zoom level is compatible with data retrieval
       var newZoom = map.getZoom();
+
+      // Delete a previous layer only if we are moving or zooming out while complying with zoom limits
+      if ( (e.type == 'dragend') || ((IsZoomCompatible(newZoom)) && (e.type == 'zoomend') && (newZoom < mapZoom)) ) {
+
+        // Delete a previous layer if it exists
+        if (map.hasLayer(dataLayer)) {
+          map.removeLayer(dataLayer);
+          kmlLayer = null;
+        }
+
+      }
+
+      // Get the new data and build a new layer if we are complying with zoom limits
       if (IsZoomCompatible(newZoom)) {
 
-        // Change the layer only if we are moving or zooming out
-        if ( (e.type == 'dragend') || ((e.type == 'zoomend') && (newZoom < mapZoom)) ) {
+        fetch(BuildUrl(thisUrl + '/wsaero.php?output=GEOJSON'))
+        .then(res => res.json())
+        .then(data => {
+          dataLayer = L.geoJSON(data, {
+            onEachFeature: onEachFeature,
+            pointToLayer: pointToLayer,
+          }).addTo(map);
+        });
 
-          // Delete a previous layer if it exists
-          if (map.hasLayer(kmlLayer)) {
-            map.removeLayer(kmlLayer);
-            kmlLayer = null;
-          }
+        // Record the new map zoom level
+        mapZoom = newZoom;
 
-          // Get the new data and build a new layer
-          fetch(BuildUrl(thisUrl + '/wsaero.php?output=KML'))
-          .then(res => res.text())
-          .then(kmltext => {
-            const parser = new DOMParser();
-            const kml = parser.parseFromString(kmltext, 'text/xml');
-            kmlLayer = new L.KML(kml);
-          map.addLayer(kmlLayer);
-          });
-
-          // Record the new map zoom level
-          mapZoom = newZoom;
-        }
       }
 
     }
@@ -136,30 +165,50 @@
 
       // Add a legend control to the map
       L.control.Legend({
-        position: "bottomleft",
-        title: "weather conditions",
+        position: 'bottomleft',
+        title: 'Flight conditions',
         column: 2,
+        collapsed: true,
         legends: [{
-          label: "VFR",
-          type: "image",
-          url: "https://maps.google.com/mapfiles/kml/pushpin/grn-pushpin.png"
+          label: 'VFR',
+          fillColor: 'green',
+          type: 'polygon',
+          sides: 4,
+          color: 'white',
+          weight: 2
           }, {
-          label: "Marginal VFR",
-          type: "image",
-          url: "https://maps.google.com/mapfiles/kml/pushpin/blue-pushpin.png"
+          label: 'Marginal VFR',
+          fillColor: 'blue',
+          type: 'polygon',
+          sides: 4,
+          color: 'white',
+          weight: 2 
           }, {
-          label: "IFR",
-          type: "image",
-          url: "https://maps.google.com/mapfiles/kml/pushpin/red-pushpin.png"
+          label: 'IFR',
+          fillColor: 'red',
+          type: 'polygon',
+          sides: 4,
+          color: 'white',
+          weight: 2 
           }, {
-          label: "Low IFR",
-          type: "image",
-          url: "https://maps.google.com/mapfiles/kml/pushpin/pink-pushpin.png"
+          label: 'Low IFR',
+          fillColor: 'black',
+          type: 'polygon',
+          sides: 4,
+          color: 'white',
+          weight: 2 
+          }, {
+         label: 'Unknown',
+          fillColor: 'lightgrey',
+          type: 'polygon',
+          sides: 4,
+          color: 'white',
+          weight: 2 
         }]
       }).addTo(map);
 
       // Set function AddKmlLayer as a listener to events "zoomend" and "dragend"
-      map.on('zoomend dragend', AddKmlLayer);
+      map.on('zoomend dragend', AddDataLayer);
 
       // Display results on the map by firing the 'dragend' event
       map.fire('dragend');

--- a/App/wsaero.css
+++ b/App/wsaero.css
@@ -1,40 +1,79 @@
 results {
-font-family: Arial, sans-serif;
+  font-family: Arial, sans-serif;
 }
 
 airport {
-display: block;
-background-color: silver;
-margin: 10px;
-padding: 10px;
+  display: block;
+  background-color: silver;
+  margin: 10px;
+  padding: 10px;
 }
 
 icao, name {
-display: inline-block;
-padding-right: 5px;
-font-weight: bold;
+  display: inline-block;
+  padding-right: 5px;
+  font-weight: bold;
 }
 
 latitude, longitude {
-display: none;
+  display: none;
 }
 
 metar, taf {
-display: block;
+  display: block;
 }
 
 [flight_cat=VFR] {
-color: green;
+  color: green;
 }
 
 [flight_cat=MVFR] {
-color: blue;
+  color: blue;
 }
 
 [flight_cat=IFR] {
-color: red;
+  color: red;
 }
 
 [flight_cat=LIFR] {
-color: magenta;
+  color: black;
+}
+
+.VFR {
+  background-color: green;
+  color: white;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+}
+.MVFR {
+  background-color: blue;
+  color: white;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+}
+.IFR {
+  background-color: red;
+  color: white;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+}
+.LIFR {
+  background-color: black;
+  color: white;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+}
+.NA {
+  background-color: lightgrey;
+  color: black;
+  font-size: large;
+  font-weight: bold;
+  text-align: center;
+  border-style: solid;
+  border-width: 1px;
+  border-color: black;
 }

--- a/App/wsaeroGeoJSON.xsl
+++ b/App/wsaeroGeoJSON.xsl
@@ -25,7 +25,7 @@
       },
       "properties": {
         "name": "<xsl:value-of select="icao"/> - <xsl:value-of select="name"/>",
-        "styleUrl": "<xsl:value-of select="metar/@flight_cat"/>"
+        "flightCat": "<xsl:value-of select="metar/@flight_cat"/>"
         <xsl:apply-templates select="metar" />
         <xsl:apply-templates select="taf" />
       }
@@ -34,11 +34,11 @@
   </xsl:template>
 
   <xsl:template match="metar">
-    ,"metar": "<![CDATA[<p>]]><xsl:value-of select="." /><![CDATA[</p>]]>"
+    ,"metar": "<xsl:value-of select="." />"
   </xsl:template>
 
   <xsl:template match="taf">
-    ,"taf": "<![CDATA[<p>]]><xsl:value-of select="." /><![CDATA[</p>]]>"
+    ,"taf": "<xsl:value-of select="." />"
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
**Replace KML with GeoJson**

- desktop.html:
  - AddKMLLayer() renamed into AddDataLayer
  - AddDataLayer() changed to drop the KML layer and use the native GeoJson layer

**Remove Google pushpins on map and legend control**

- desktop.html:
  - Use L.divIcon instead of icon images
  - Use Polygons (4 sides) instead of Images on legend
- wsaero.css:
  - Add new class names associated with the L.divIcon objects

**Data Layer optimization: fix**

- desktop.html:
  - layer deletion and layer creation split with 2 distinct conditions

**ToolTip added to the map**

- desktop.html (feature added with the new function pointToLayer

**html formatting removed on the GeoJson output for properties.metar and properties.taf**

- wsaeroGeoJSON.xsl 